### PR TITLE
Docker med docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,24 @@ I github finns det ett ganska bra stöd för att skapa issues där man kan lägg
 
 Vi är fortfarande otroligt mycket i uppstartsfasen av det hela, så ifall ni har några idéer eller tankar så är allt välkommet!
 
+### How to
+
+Har dockerifierat applikationen.
+Och för att det ska fungera så behöver man installera docker och docker-compose
+
+på windows finns det docker-toolbox som installerar allt åt en
+på unix så får man installera docker, och sen docker-compose separat :)
+
+```bash
+# För att köra docker (disabla enhetstesten eftersom de inte fungerar just nu)
+mvn clean install -Pdocker -DskipTests
+
+# Starta applikationen i docker containrar (user-services och postgres) (-d lägger processerna i bakgrunden)
+docker-compose up -d
+
+# För att följa loggarna
+docker-compose logs -f
+
+# För att stänga av applikationen
+docker-compose kill
+```

--- a/user-services/docker-compose.yml
+++ b/user-services/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "2"
+
+services:
+  user-services:
+    container_name: "user-services"
+    image: claremont/clarty-user-services
+    links:
+      - user-services-db:user-services-db
+    ports:
+      - "8080:8080"
+
+  user-services-db:
+    container_name: "postgresql"
+    image: postgres:alpine
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_USER=clarty
+      - POSTGRES_DB=user-services
+    ports:
+      - "5432:5432"
+

--- a/user-services/pom.xml
+++ b/user-services/pom.xml
@@ -130,4 +130,38 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>docker</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.spotify</groupId>
+						<artifactId>docker-maven-plugin</artifactId>
+						<version>0.4.13</version>
+						<executions>
+							<execution>
+								<phase>post-integration-test</phase>
+								<goals>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<imageName>claremont/${project.artifactId}</imageName>
+							<dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+							<resources>
+								<resource>
+									<targetPath>/</targetPath>
+									<directory>${project.build.directory}</directory>
+									<include>${project.build.finalName}.jar</include>
+								</resource>
+							</resources>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/user-services/src/main/docker/Dockerfile
+++ b/user-services/src/main/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:8-jre-alpine
+VOLUME /tmp
+ADD clarty-user-services.jar clarty-user-services.jar
+RUN sh -c 'touch /clarty-user-services.jar'
+ENV JAVA_OPTS=""
+ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Dspring.profiles.active=docker -Djava.security.egd=file:/dev/./urandom -jar /clarty-user-services.jar" ]

--- a/user-services/src/main/resources/application-docker.properties
+++ b/user-services/src/main/resources/application-docker.properties
@@ -1,0 +1,15 @@
+clarty.jpa.database=POSTGRESQL
+clarty.datasource.platform=postgres
+spring.jpa.show-sql=true
+logging.level.org.hibernate.SQL=DEBUG
+clarty.datasource.host=localhost
+clarty.datasource.port=5432
+clarty.datasource.database=clartybootdb
+clarty.datasource.url= jdbc:postgresql://user-services-db:5432/user-services 
+clarty.datasource.username=postgres
+clarty.datasource.password=clarty   
+clarty.database.driverClassName=org.postgresql.Driver   
+clarty.jpa.hibernate.ddl-auto=create-drop
+server.port=8080
+
+database.type=postgresql


### PR DESCRIPTION
När jag ändå var i farten.. La till så att man kan använda docker och docker-compose om man vill det..

Docker är som en virtualiserad miljö (typ virtualbox fast mindre och snabbare) där man lägger applikationen så att man får total kontrol på hur miljön ser ut där den körs, vilket gör det lättare vid releaser, testning och miljöuppsättning..

docker-compose är ett verktyg kopplat till det, som hjälper till att få ihop kontakten mellan flera docker "containrar" som det heter när man kör de uppskapade miljöerna.

Så i det här fallet kör vi mvn clean install -Pdocker för att skapa en docker miljö, sen docker-compose up för att starta upp user-services.jar och en postgresql databas, och låta dem prata med varandra